### PR TITLE
Fix MJ-RF conversion calculation

### DIFF
--- a/api/buildcraft/api/mj/MjCapabilityHelper.java
+++ b/api/buildcraft/api/mj/MjCapabilityHelper.java
@@ -97,7 +97,7 @@ public class MjCapabilityHelper implements ICapabilityProvider {
                     // (We need to actual accepted MJ to be some integer multiple of mjPerRf)
                     long excessMj = acceptedMj % mjPerRf;
                     // An MJ value that is an integer multiple of mjPerRf
-                    long exactAcceptableMj = maxReceiveMj - excessMj;
+                    long exactAcceptableMj = acceptedMj - excessMj;
 
                     if (exactAcceptableMj <= 0) {
                         return 0;


### PR DESCRIPTION
The RF->MJ->RF conversion in `receiveEnergy()` was using the max receiveable MJ `maxReceiveMJ`, the amount before passing the power to the `IMjReceiver`, to calculate resultant RF. It should use the post-recieved, actual accepted amount of power by the MJ receiver `acceptedMj`. This caused a discrepancy in the amount of excessMJ (calculated based on post-receive), and the amount it was subtracted from (based on pre-receive) to calculate `exactAcceptedMj`.

This caused crashes like [this](https://mclo.gs/wb76EtF). This crash can be recreated with minimal mods in the below scenario: 
<img width="854" height="480" alt="2025-10-29_18 44 44" src="https://github.com/user-attachments/assets/0b4f491e-e57e-4fc9-b778-01f6198686aa" />
An Extra Utilities (XU2) Energy Transfer node (extracting from an XU2 Creative Energy Source) with cable connected to an obsidian pipe, and throwing any item into the obsidian pipe. I've verified in a minimal instance (Buildcraft + Extra Utiltiies) that this setup no longer crashes with the changes.

Should fix BuildCraft/BuildCraft#4730, it's a similar crash.